### PR TITLE
Disable nullable reference types

### DIFF
--- a/SqlServerToPlantUML/SqlServerToPlantUML.csproj
+++ b/SqlServerToPlantUML/SqlServerToPlantUML.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.1.42" />


### PR DESCRIPTION
## Summary
- switch `<Nullable>` setting from `enable` to `disable` to deactivate nullable reference warnings

## Testing
- `dotnet build SqlServerToPlantUML/SqlServerToPlantUML.csproj -c Release`