### PR TITLE
Add tests and injection for DB2ERD

### DIFF
--- a/DB2ERD.Tests/Controller/GeneratePlantUMLDiagramTests.cs
+++ b/DB2ERD.Tests/Controller/GeneratePlantUMLDiagramTests.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using System.IO;
+using DB2ERD.Controller;
+using DB2ERD.Model;
+using Xunit;
+
+namespace DB2ERD.Tests.Controller;
+
+public class GeneratePlantUMLDiagramTests
+{
+    [Fact]
+    public void GenerateAllRelationships_WritesExpectedUml()
+    {
+        var table1 = new SqlTable
+        {
+            schema_name = "dbo",
+            table_name = "Table1",
+            full_name = "dbo.Table1",
+            columnList = new List<SqlColumn>
+            {
+                new SqlColumn { column_name = "Id", data_type = "int", is_primary_key = true },
+                new SqlColumn { column_name = "Name", data_type = "nvarchar" }
+            }
+        };
+        var table2 = new SqlTable
+        {
+            schema_name = "dbo",
+            table_name = "Table2",
+            full_name = "dbo.Table2",
+            columnList = new List<SqlColumn>
+            {
+                new SqlColumn { column_name = "Id", data_type = "int", is_primary_key = true }
+            }
+        };
+        table1.foreign_key_list.Add(new ForeignKeyConstraint
+        {
+            fk_schema_name = "dbo",
+            fk_table_name = "Table1",
+            pk_schema_name = "dbo",
+            pk_table_name = "Table2",
+            foreign_key_name = "FK_Table1_Table2"
+        });
+
+        var tables = new List<SqlTable> { table1, table2 };
+        var file = Path.GetTempFileName();
+        try
+        {
+            var uml = GeneratePlantUMLDiagram.GenerateAllRelationships(tables, "ERD", file);
+            var fileContent = File.ReadAllText(file);
+            Assert.Equal(uml, fileContent);
+            Assert.Contains("table( dbo.Table1 )", uml);
+            Assert.Contains("table( dbo.Table2 )", uml);
+            Assert.Contains("dbo.Table1 }|--|| dbo.Table2", uml);
+        }
+        finally
+        {
+            if (File.Exists(file))
+                File.Delete(file);
+        }
+    }
+}

--- a/DB2ERD.Tests/DB2ERD.Tests.csproj
+++ b/DB2ERD.Tests/DB2ERD.Tests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DB2ERD\DB2ERD.csproj" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.10">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/DB2ERD.Tests/GenerateCommandTests.cs
+++ b/DB2ERD.Tests/GenerateCommandTests.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using System.IO;
+using DB2ERD;
+using DB2ERD.Controller;
+using DB2ERD.Model;
+using Xunit;
+
+namespace DB2ERD.Tests;
+
+public class GenerateCommandTests
+{
+    private class FakeGenerator : ITableGenerator
+    {
+        public List<SqlTable> Tables { get; set; } = new();
+        public string? LastQuery { get; private set; }
+        public List<SqlTable> Execute(string tableQuery, List<string>? include = null, List<string>? exclude = null)
+        {
+            LastQuery = tableQuery;
+            return Tables;
+        }
+    }
+
+    [Fact]
+    public void Execute_ReturnsErrorWhenMissingConnectionString()
+    {
+        var cmd = new GenerateCommand();
+        var result = cmd.Execute(null!, new GenerateCommand.Settings{ Config="nonexistent.json" });
+        Assert.Equal(-1, result);
+    }
+
+    [Fact]
+    public void Execute_WritesOutputFile()
+    {
+        var fake = new FakeGenerator();
+        fake.Tables.Add(new SqlTable
+        {
+            schema_name = "dbo",
+            table_name = "T",
+            full_name = "dbo.T",
+            columnList = new List<SqlColumn>{ new SqlColumn{ column_name="Id", data_type="int" } }
+        });
+        var file = Path.GetTempFileName();
+        try
+        {
+            var cmd = new GenerateCommand { TableGenerator = fake };
+            var settings = new GenerateCommand.Settings
+            {
+                ConnectionString = "fake",
+                TableQuery = "SELECT",
+                Output = file,
+                Config = "nonexistent.json"
+            };
+            var code = cmd.Execute(null!, settings);
+            Assert.Equal(0, code);
+            Assert.True(File.Exists(file));
+            Assert.Contains("table( dbo.T )", File.ReadAllText(file));
+        }
+        finally
+        {
+            if (File.Exists(file))
+                File.Delete(file);
+        }
+    }
+}

--- a/DB2ERD.sln
+++ b/DB2ERD.sln
@@ -4,6 +4,8 @@ VisualStudioVersion = 16.0.32228.343
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DB2ERD", "DB2ERD\DB2ERD.csproj", "{46E4A096-63A4-42D2-934D-38867FB11081}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DB2ERD.Tests", "DB2ERD.Tests\DB2ERD.Tests.csproj", "{5197B1A3-856F-4AE0-A653-1C8028079C19}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -14,6 +16,10 @@ Global
 		{46E4A096-63A4-42D2-934D-38867FB11081}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{46E4A096-63A4-42D2-934D-38867FB11081}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{46E4A096-63A4-42D2-934D-38867FB11081}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5197B1A3-856F-4AE0-A653-1C8028079C19}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5197B1A3-856F-4AE0-A653-1C8028079C19}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5197B1A3-856F-4AE0-A653-1C8028079C19}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5197B1A3-856F-4AE0-A653-1C8028079C19}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/DB2ERD/Controller/GenerateSqlServerTables.cs
+++ b/DB2ERD/Controller/GenerateSqlServerTables.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace DB2ERD.Controller
 {
-    public class GenerateSqlServerTables
+    public class GenerateSqlServerTables : ITableGenerator
     {
         private SqlConnection m_sqlConn;
         private string m_connStr;

--- a/DB2ERD/Controller/ITableGenerator.cs
+++ b/DB2ERD/Controller/ITableGenerator.cs
@@ -1,0 +1,11 @@
+namespace DB2ERD.Controller;
+
+using DB2ERD.Model;
+using System.Collections.Generic;
+
+public interface ITableGenerator
+{
+    List<SqlTable> Execute(string tableQuery,
+        List<string>? tablesToInclude = null,
+        List<string>? tablesToExclude = null);
+}

--- a/DB2ERD/Program.cs
+++ b/DB2ERD/Program.cs
@@ -18,6 +18,12 @@ internal class Program
 
 public class GenerateCommand : Command<GenerateCommand.Settings>
 {
+    /// <summary>
+    /// Optional table generator used for testing. When not set, the command
+    /// will create an instance of <see cref="GenerateSqlServerTables"/> at
+    /// runtime.
+    /// </summary>
+    internal ITableGenerator? TableGenerator { get; set; }
     public class Settings : CommandSettings
     {
         [CommandOption("-c|--config <FILE>")]
@@ -64,7 +70,7 @@ public class GenerateCommand : Command<GenerateCommand.Settings>
         var query = settings.TableQuery ?? config?.TableQuery ??
             "SELECT schema_id, SCHEMA_NAME(schema_id) as [schema_name], name as table_name, object_id, '['+SCHEMA_NAME(schema_id)+'].['+name+']' AS full_name FROM sys.tables where is_ms_shipped = 0";
 
-        var generator = new GenerateSqlServerTables(connectionString);
+        var generator = TableGenerator ?? new GenerateSqlServerTables(connectionString);
         var tables = generator.Execute(query);
         // add a check for empty tables
         if (tables == null || tables.Count == 0)


### PR DESCRIPTION
## Summary
- add `ITableGenerator` abstraction for reading tables
- allow `GenerateCommand` to use an injected `ITableGenerator`
- implement tests verifying PlantUML generation and command execution behaviors
- modify test package versions and clarify test injection

## Testing
- `dotnet test DB2ERD.sln --verbosity normal` *(fails: unable to retrieve xunit packages)*