### PR TITLE
Clean up unused using directives

### DIFF
--- a/DB2ERD/Controller/GeneratePlantUMLDiagram.cs
+++ b/DB2ERD/Controller/GeneratePlantUMLDiagram.cs
@@ -1,10 +1,8 @@
-﻿using DB2ERD.Model;
-using System.Threading.Tasks;
+using DB2ERD.Model;
 using System.Text;
 using System.Linq;
 using System.IO;
 using System.Collections.Generic;
-using System;
 
 
 namespace DB2ERD.Controller

--- a/DB2ERD/Controller/GenerateSqlServerTables.cs
+++ b/DB2ERD/Controller/GenerateSqlServerTables.cs
@@ -1,12 +1,7 @@
-﻿using Dapper;
+using Dapper;
 using DB2ERD.Model;
-using System;
-using System.Collections.Generic;
 using Microsoft.Data.SqlClient;
-using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Spectre.Console;
 
 namespace DB2ERD.Controller

--- a/DB2ERD/Model/ForeignKeyConstraint.cs
+++ b/DB2ERD/Model/ForeignKeyConstraint.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace DB2ERD.Model
 {

--- a/DB2ERD/Model/SqlColumn.cs
+++ b/DB2ERD/Model/SqlColumn.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace DB2ERD.Model
 {

--- a/DB2ERD/Model/SqlTable.cs
+++ b/DB2ERD/Model/SqlTable.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace DB2ERD.Model
 {


### PR DESCRIPTION
## Summary
- remove unused `using` directives in controller and model classes

## Testing
- `dotnet build DB2ERD.sln --no-restore`
- `dotnet test DB2ERD.sln --no-build`
