### PR TITLE
Remove unused field from SQL generator

### DIFF
--- a/DB2ERD/Controller/GenerateSqlServerTables.cs
+++ b/DB2ERD/Controller/GenerateSqlServerTables.cs
@@ -10,7 +10,6 @@ namespace DB2ERD.Controller
     {
         private string m_connStr;
         private List<SqlTable> m_tableList = new List<SqlTable>();
-        private string m_database;
 
         public GenerateSqlServerTables(string dbConnString)
         {


### PR DESCRIPTION
## Summary
- drop the unused `m_database` field from `GenerateSqlServerTables`

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build`
