### PR TITLE
Add CI/CD build and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,61 @@
+name: Build and Release
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (for example v1.0.0)'
+        required: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 8.0.x
+      - run: dotnet restore
+      - run: dotnet build --configuration Release --no-restore
+      - run: dotnet test --no-build --configuration Release
+
+  publish:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 8.0.x
+      - name: Publish Windows build
+        run: dotnet publish DB2ERD/DB2ERD.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -o publish/win-x64
+      - name: Publish Linux build
+        run: dotnet publish DB2ERD/DB2ERD.csproj -c Release -r linux-x64 --self-contained true -p:PublishSingleFile=true -o publish/linux-x64
+      - name: Create tag when run manually
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.tag != ''
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@users.noreply.github.com"
+          git tag ${{ github.event.inputs.tag }}
+          git push origin ${{ github.event.inputs.tag }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: windows
+          path: publish/win-x64
+      - uses: actions/upload-artifact@v3
+        with:
+          name: linux
+          path: publish/linux-x64
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
+          files: |
+            publish/win-x64/**
+            publish/linux-x64/**
+


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to build, test and publish executables
- build self-contained Windows and Linux binaries
- create release artifacts and optional tag when run manually

## Testing
- `dotnet build`
- `dotnet test`
