### PR TITLE
Enable publish job on pull requests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,18 +25,14 @@ jobs:
       - run: dotnet test --no-build --configuration Release
 
   publish:
+    if: github.event_name != 'pull_request'
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - name: Skipping publish on pull requests
-        if: github.event_name == 'pull_request'
-        run: echo "Publish steps are skipped on pull requests"
       - uses: actions/checkout@v3
-        if: github.event_name != 'pull_request'
         with:
           fetch-depth: 0
       - name: Update VERSION
-        if: github.event_name != 'pull_request'
         run: |
           VERSION="${{ github.event.inputs.tag || github.ref_name }}"
           VERSION="${VERSION#refs/tags/}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,14 +25,18 @@ jobs:
       - run: dotnet test --no-build --configuration Release
 
   publish:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - name: Skipping publish on pull requests
+        if: github.event_name == 'pull_request'
+        run: echo "Publish steps are skipped on pull requests"
       - uses: actions/checkout@v3
+        if: github.event_name != 'pull_request'
         with:
           fetch-depth: 0
       - name: Update VERSION
+        if: github.event_name != 'pull_request'
         run: |
           VERSION="${{ github.event.inputs.tag || github.ref_name }}"
           VERSION="${VERSION#refs/tags/}"
@@ -64,13 +68,17 @@ jobs:
             fi
           fi
       - uses: actions/setup-dotnet@v4
+        if: github.event_name != 'pull_request'
         with:
           dotnet-version: 8.0.x
       - name: Publish Windows build
+        if: github.event_name != 'pull_request'
         run: dotnet publish DB2ERD/DB2ERD.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -o publish/win-x64
       - name: Publish Linux build
+        if: github.event_name != 'pull_request'
         run: dotnet publish DB2ERD/DB2ERD.csproj -c Release -r linux-x64 --self-contained true -p:PublishSingleFile=true -o publish/linux-x64
       - name: List generated artifacts
+        if: github.event_name != 'pull_request'
         run: ls -R publish
       - name: Create tag when run manually
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.tag != ''
@@ -80,15 +88,18 @@ jobs:
           git tag ${{ github.event.inputs.tag }}
           git push origin ${{ github.event.inputs.tag }}
       - name: Upload artifacts
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: windows
           path: publish/win-x64
       - uses: actions/upload-artifact@v4
+        if: github.event_name != 'pull_request'
         with:
           name: linux
           path: publish/linux-x64
       - name: Create GitHub Release
+        if: github.event_name != 'pull_request'
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ github.event.inputs.tag || github.ref_name }}


### PR DESCRIPTION
## Summary
- ensure the `publish` job runs on PRs
- skip the heavy publishing steps when triggered by `pull_request`

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_b_683efaeb65e0832a95bdfc4ab3f14d42