### PR TITLE
Add config-based query test

### DIFF
--- a/DB2ERD/Program.cs
+++ b/DB2ERD/Program.cs
@@ -87,7 +87,14 @@ public class ErdGeneration : Command<ErdGeneration.Settings>
             _ => string.Empty
         };
 
-        var query = settings.TableQuery ?? config?.TableQuery ?? defaultQuery;
+        // Prefer a query passed on the command line. If none is specified,
+        // look for one in the configuration file. When both are missing or
+        // blank, fall back to the built-in default for the selected database.
+        var query = !string.IsNullOrWhiteSpace(settings.TableQuery)
+            ? settings.TableQuery
+            : !string.IsNullOrWhiteSpace(config?.TableQuery)
+                ? config.TableQuery
+                : defaultQuery;
 
         var generator = TableGenerator ?? dbType switch
         {


### PR DESCRIPTION
## Summary
- test using config-supplied TableQuery
- ensure default query used when config omits TableQuery
- fix `ErdGeneration` to respect empty config values
- add comment describing table query selection logic

## Testing
- `dotnet test --no-restore --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_b_684b9c940dd4832a88454bc1d572aeb9