### PR TITLE
Add missing test for Execute with no tables

### DIFF
--- a/DB2ERD.Tests/ERDGenerationTests.cs
+++ b/DB2ERD.Tests/ERDGenerationTests.cs
@@ -144,6 +144,33 @@ public class ERDGenerationTests
     }
 
     [Fact]
+    public void Should_ReturnErrorCode_When_NoTablesAreReturned()
+    {
+        var fake = new FakeGenerator();
+        var file = Path.GetTempFileName();
+        try
+        {
+            var cmd = new ErdGeneration { TableGenerator = fake };
+            var settings = new ErdGeneration.Settings
+            {
+                ConnectionString = "fake",
+                TableQuery = "SELECT",
+                Output = file,
+                Config = "nonexistent.json"
+            };
+
+            var code = cmd.Execute(null!, settings);
+
+            Assert.Equal(-1, code);
+        }
+        finally
+        {
+            if (File.Exists(file))
+                File.Delete(file);
+        }
+    }
+
+    [Fact]
     public void Should_ReadQueryFromConfig_AndFallbackToDefault()
     {
         // Arrange a fake generator with one table so Execute succeeds


### PR DESCRIPTION
## Summary
- add ERDGeneration test for no tables returned

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_b_684ba483c194832ab18b9cdae2831fe5