### PR TITLE
Repo MCP candidacy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added .editorconfig for consistent code style
 - Added CI badge to README
 - Added security and contributing sections to README
+- Added MCP-friendly CLI commands:
+  - `list-supported-databases` for capability discovery
+  - `get-schema-metadata` for structured schema JSON
+  - `generate-erd-puml` for structured PlantUML JSON with optional file output
+
+### MCP Readiness
+- Added structured JSON success/error envelopes for machine callers
+- Added bounded response controls with `--max-tables` and `--max-output-chars`
+- Added explicit custom SQL opt-in with `--allow-custom-query` for safer defaults
+- Added generator flags for silent mode and fail-fast error propagation in machine workflows
 
 ### Note on Naming Conventions
 Model classes (SqlTable, SqlColumn, ForeignKeyConstraint) intentionally use snake_case for public properties to maintain compatibility with database metadata column names and existing code. While this differs from standard C# conventions, it simplifies data mapping and reduces the need for additional annotations. Future major versions may consider a migration to PascalCase with appropriate mapping attributes.

--- a/DB2ERD.Tests/McpCommandsTests.cs
+++ b/DB2ERD.Tests/McpCommandsTests.cs
@@ -1,0 +1,232 @@
+using DB2ERD.Commands;
+using DB2ERD.Controller;
+using DB2ERD.Model;
+using Spectre.Console.Cli;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using Xunit;
+
+namespace DB2ERD.Tests;
+
+public class McpCommandsTests
+{
+    private static readonly object ConsoleLock = new();
+
+    private sealed class FakeGenerator : ITableGenerator
+    {
+        public List<SqlTable> Tables { get; set; } = new();
+        public string LastQuery { get; private set; }
+
+        public List<SqlTable> Execute(string tableQuery, List<string> tablesToInclude = null, List<string> tablesToExclude = null)
+        {
+            LastQuery = tableQuery;
+            return Tables;
+        }
+    }
+
+    [Fact]
+    public void ListSupportedDatabases_Should_ReturnJsonPayload()
+    {
+        var command = new ListSupportedDatabasesCommand();
+        var settings = new ListSupportedDatabasesCommand.Settings();
+
+        var (exitCode, output) = ExecuteWithOutput(command, settings);
+        using var json = JsonDocument.Parse(output);
+
+        Assert.Equal(0, exitCode);
+        Assert.True(json.RootElement.GetProperty("success").GetBoolean());
+
+        var databases = json.RootElement
+            .GetProperty("data")
+            .GetProperty("databases")
+            .EnumerateArray()
+            .Select(x => x.GetProperty("name").GetString())
+            .ToList();
+
+        Assert.Contains("SqlServer", databases);
+        Assert.Contains("Oracle", databases);
+        Assert.Contains("PostgreSql", databases);
+        Assert.Contains("MySql", databases);
+    }
+
+    [Fact]
+    public void GetSchemaMetadata_Should_BlockCustomQuery_WithoutExplicitOptIn()
+    {
+        var command = new GetSchemaMetadataCommand();
+        var settings = new GetSchemaMetadataCommand.Settings
+        {
+            Config = "nonexistent.json",
+            ConnectionString = "fake-connection",
+            TableQuery = "SELECT * FROM sys.tables"
+        };
+
+        var (exitCode, output) = ExecuteWithOutput(command, settings);
+        using var json = JsonDocument.Parse(output);
+
+        Assert.Equal(-1, exitCode);
+        Assert.False(json.RootElement.GetProperty("success").GetBoolean());
+        Assert.Equal("CUSTOM_QUERY_NOT_ALLOWED", json.RootElement.GetProperty("errorCode").GetString());
+    }
+
+    [Fact]
+    public void GetSchemaMetadata_Should_ReturnBoundedTableList()
+    {
+        var fake = new FakeGenerator
+        {
+            Tables =
+            [
+                new SqlTable
+                {
+                    schema_name = "dbo",
+                    table_name = "First",
+                    full_name = "dbo.First",
+                    columnList = [ new SqlColumn { column_name = "Id", data_type = "int" } ]
+                },
+                new SqlTable
+                {
+                    schema_name = "dbo",
+                    table_name = "Second",
+                    full_name = "dbo.Second",
+                    columnList = [ new SqlColumn { column_name = "Id", data_type = "int" } ]
+                }
+            ]
+        };
+
+        var command = new GetSchemaMetadataCommand { TableGenerator = fake };
+        var settings = new GetSchemaMetadataCommand.Settings
+        {
+            Config = "nonexistent.json",
+            ConnectionString = "fake-connection",
+            MaxTables = 1
+        };
+
+        var (exitCode, output) = ExecuteWithOutput(command, settings);
+        using var json = JsonDocument.Parse(output);
+
+        Assert.Equal(0, exitCode);
+        Assert.True(json.RootElement.GetProperty("success").GetBoolean());
+        Assert.True(json.RootElement.GetProperty("data").GetProperty("truncated").GetBoolean());
+        Assert.Equal(2, json.RootElement.GetProperty("data").GetProperty("totalTableCount").GetInt32());
+        Assert.Equal(1, json.RootElement.GetProperty("data").GetProperty("returnedTableCount").GetInt32());
+        Assert.Contains("sys.tables", fake.LastQuery);
+    }
+
+    [Fact]
+    public void GenerateErdPuml_Should_ReturnPlantUmlText_WithoutFileOutput()
+    {
+        var fake = new FakeGenerator
+        {
+            Tables =
+            [
+                new SqlTable
+                {
+                    schema_name = "dbo",
+                    table_name = "Parent",
+                    full_name = "dbo.Parent",
+                    columnList = [new SqlColumn { column_name = "Id", data_type = "int", is_primary_key = true }]
+                },
+                new SqlTable
+                {
+                    schema_name = "dbo",
+                    table_name = "Child",
+                    full_name = "dbo.Child",
+                    columnList =
+                    [
+                        new SqlColumn { column_name = "Id", data_type = "int", is_primary_key = true },
+                        new SqlColumn { column_name = "ParentId", data_type = "int", is_foreign_key = true }
+                    ],
+                    foreign_key_list =
+                    [
+                        new ForeignKeyConstraint
+                        {
+                            fk_schema_name = "dbo",
+                            fk_table_name = "Child",
+                            pk_schema_name = "dbo",
+                            pk_table_name = "Parent",
+                            foreign_key_name = "FK_Child_Parent"
+                        }
+                    ]
+                }
+            ]
+        };
+
+        var command = new GenerateErdPumlCommand { TableGenerator = fake };
+        var settings = new GenerateErdPumlCommand.Settings
+        {
+            Config = "nonexistent.json",
+            ConnectionString = "fake-connection"
+        };
+
+        var (exitCode, output) = ExecuteWithOutput(command, settings);
+        using var json = JsonDocument.Parse(output);
+
+        Assert.Equal(0, exitCode);
+        Assert.True(json.RootElement.GetProperty("success").GetBoolean());
+        var puml = json.RootElement.GetProperty("data").GetProperty("puml").GetString();
+        Assert.Contains("@startuml", puml);
+        Assert.Contains("table( dbo.Parent )", puml);
+    }
+
+    [Fact]
+    public void GenerateErdPuml_Should_TruncateLargeTextInJsonResponse()
+    {
+        var fake = new FakeGenerator
+        {
+            Tables =
+            [
+                new SqlTable
+                {
+                    schema_name = "dbo",
+                    table_name = "Only",
+                    full_name = "dbo.Only",
+                    columnList =
+                    [
+                        new SqlColumn { column_name = "Id", data_type = "int", is_primary_key = true },
+                        new SqlColumn { column_name = "Name", data_type = "nvarchar" }
+                    ]
+                }
+            ]
+        };
+
+        var command = new GenerateErdPumlCommand { TableGenerator = fake };
+        var settings = new GenerateErdPumlCommand.Settings
+        {
+            Config = "nonexistent.json",
+            ConnectionString = "fake-connection",
+            MaxOutputChars = 40,
+            Mode = "all-tables"
+        };
+
+        var (exitCode, output) = ExecuteWithOutput(command, settings);
+        using var json = JsonDocument.Parse(output);
+
+        Assert.Equal(0, exitCode);
+        Assert.True(json.RootElement.GetProperty("success").GetBoolean());
+        Assert.True(json.RootElement.GetProperty("data").GetProperty("pumlTruncated").GetBoolean());
+        Assert.Equal(40, json.RootElement.GetProperty("data").GetProperty("puml").GetString().Length);
+    }
+
+    private static (int ExitCode, string Output) ExecuteWithOutput<TSettings>(Command<TSettings> command, TSettings settings)
+        where TSettings : CommandSettings
+    {
+        lock (ConsoleLock)
+        {
+            var originalOut = Console.Out;
+            using var capture = new StringWriter();
+
+            try
+            {
+                Console.SetOut(capture);
+                var exitCode = command.Execute(null!, settings);
+                return (exitCode, capture.ToString().Trim());
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+            }
+        }
+    }
+}

--- a/DB2ERD/Commands/DatabaseCommandSupport.cs
+++ b/DB2ERD/Commands/DatabaseCommandSupport.cs
@@ -1,0 +1,261 @@
+using DB2ERD.Controller;
+using DB2ERD.Model;
+using System.Text.Json;
+
+namespace DB2ERD.Commands;
+
+internal static class DatabaseCommandSupport
+{
+    private static readonly JsonSerializerOptions CompactJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    private static readonly JsonSerializerOptions PrettyJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true
+    };
+
+    public static bool TryResolveRequest(
+        DatabaseAccessSettings settings,
+        bool safeQueryMode,
+        out ResolvedDatabaseRequest request,
+        out string errorCode,
+        out string errorMessage)
+    {
+        request = null;
+        errorCode = string.Empty;
+        errorMessage = string.Empty;
+
+        if (!TryReadConfig(settings.Config, out var config, out errorCode, out errorMessage))
+        {
+            return false;
+        }
+
+        var connectionString = settings.ConnectionString ?? config?.ConnectionString;
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            errorCode = "MISSING_CONNECTION_STRING";
+            errorMessage = "Connection string is required.";
+            return false;
+        }
+
+        var dbTypeString = settings.DatabaseType ?? config?.DatabaseType ?? "SqlServer";
+        if (!Enum.TryParse<DatabaseType>(dbTypeString, true, out var dbType))
+        {
+            errorCode = "UNKNOWN_DATABASE_TYPE";
+            errorMessage = $"Unknown database type: {dbTypeString}.";
+            return false;
+        }
+
+        if (safeQueryMode && !string.IsNullOrWhiteSpace(settings.TableQuery) && !settings.AllowCustomQuery)
+        {
+            errorCode = "CUSTOM_QUERY_NOT_ALLOWED";
+            errorMessage = "Custom table queries are disabled by default. Pass --allow-custom-query to enable them explicitly.";
+            return false;
+        }
+
+        var defaultQuery = GetDefaultTableQuery(dbType);
+        var query = defaultQuery;
+        if (!safeQueryMode || settings.AllowCustomQuery)
+        {
+            query = !string.IsNullOrWhiteSpace(settings.TableQuery)
+                ? settings.TableQuery
+                : !string.IsNullOrWhiteSpace(config?.TableQuery)
+                    ? config.TableQuery
+                    : defaultQuery;
+        }
+
+        request = new ResolvedDatabaseRequest
+        {
+            ConnectionString = connectionString,
+            DatabaseType = dbType,
+            Query = query
+        };
+
+        return true;
+    }
+
+    public static ITableGenerator CreateTableGenerator(
+        DatabaseType dbType,
+        string connectionString,
+        bool verbose,
+        bool throwOnError)
+    {
+        return dbType switch
+        {
+            DatabaseType.Oracle => new GenerateOracleTables(connectionString, verbose, throwOnError),
+            DatabaseType.PostgreSql => new GeneratePostgreSqlTables(connectionString, verbose, throwOnError),
+            DatabaseType.MySql => new GenerateMySqlTables(connectionString, verbose, throwOnError),
+            _ => new GenerateSqlServerTables(connectionString, verbose, throwOnError)
+        };
+    }
+
+    public static List<string> ParseTableList(string csv)
+    {
+        if (string.IsNullOrWhiteSpace(csv))
+        {
+            return null;
+        }
+
+        var values = csv
+            .Split(',', StringSplitOptions.RemoveEmptyEntries)
+            .Select(x => x.Trim())
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        return values.Count == 0 ? null : values;
+    }
+
+    public static List<SqlTable> ApplyTableLimit(List<SqlTable> tables, int maxTables, out bool truncated, out int totalTableCount)
+    {
+        tables ??= new List<SqlTable>();
+        totalTableCount = tables.Count;
+        truncated = false;
+
+        if (maxTables <= 0 || tables.Count <= maxTables)
+        {
+            return tables;
+        }
+
+        truncated = true;
+        return tables.Take(maxTables).ToList();
+    }
+
+    public static int CountRelationships(List<SqlTable> tables)
+    {
+        if (tables == null || tables.Count == 0)
+        {
+            return 0;
+        }
+
+        return tables.Sum(t => t.foreign_key_list?.Count ?? 0);
+    }
+
+    public static string GetDefaultTableQuery(DatabaseType dbType)
+    {
+        return dbType switch
+        {
+            DatabaseType.SqlServer => "SELECT schema_id, SCHEMA_NAME(schema_id) as [schema_name], name as table_name, object_id, '['+SCHEMA_NAME(schema_id)+'].['+name+']' AS full_name FROM sys.tables where is_ms_shipped = 0",
+            DatabaseType.Oracle => "SELECT owner AS schema_name, table_name, owner||'.'||table_name AS full_name FROM all_tables WHERE owner NOT IN ('SYS','SYSTEM')",
+            DatabaseType.PostgreSql => "SELECT table_schema AS schema_name, table_name, table_schema||'.'||table_name AS full_name FROM information_schema.tables WHERE table_type='BASE TABLE' AND table_schema NOT IN ('pg_catalog','information_schema')",
+            DatabaseType.MySql => "SELECT table_schema AS schema_name, table_name, CONCAT(table_schema,'.',table_name) AS full_name FROM information_schema.tables WHERE table_type='BASE TABLE' AND table_schema = DATABASE()",
+            _ => string.Empty
+        };
+    }
+
+    public static void WriteSuccess<T>(T data, bool prettyJson)
+    {
+        var envelope = new JsonEnvelope<T>
+        {
+            Success = true,
+            ErrorCode = string.Empty,
+            Message = string.Empty,
+            Data = data
+        };
+        WriteEnvelope(envelope, prettyJson);
+    }
+
+    public static void WriteError(string errorCode, string message, bool prettyJson)
+    {
+        var envelope = new JsonEnvelope<object>
+        {
+            Success = false,
+            ErrorCode = errorCode,
+            Message = message,
+            Data = null
+        };
+        WriteEnvelope(envelope, prettyJson);
+    }
+
+    private static void WriteEnvelope<T>(JsonEnvelope<T> envelope, bool prettyJson)
+    {
+        var options = prettyJson ? PrettyJsonOptions : CompactJsonOptions;
+        Console.Out.WriteLine(JsonSerializer.Serialize(envelope, options));
+    }
+
+    private static bool TryReadConfig(string configPath, out AppConfig config, out string errorCode, out string errorMessage)
+    {
+        config = null;
+        errorCode = string.Empty;
+        errorMessage = string.Empty;
+
+        if (!File.Exists(configPath))
+        {
+            return true;
+        }
+
+        try
+        {
+            var json = File.ReadAllText(configPath);
+            config = JsonSerializer.Deserialize<AppConfig>(json);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            errorCode = "CONFIG_READ_FAILED";
+            errorMessage = $"Failed to read configuration: {ex.Message}";
+            return false;
+        }
+    }
+}
+
+internal sealed class JsonEnvelope<T>
+{
+    public bool Success { get; set; }
+    public string ErrorCode { get; set; }
+    public string Message { get; set; }
+    public T Data { get; set; }
+}
+
+internal abstract class DatabaseAccessSettings : Spectre.Console.Cli.CommandSettings
+{
+    [Spectre.Console.Cli.CommandOption("-c|--config <FILE>")]
+    [System.ComponentModel.Description("Path to configuration JSON file")]
+    public string Config { get; set; } = "appsettings.json";
+
+    [Spectre.Console.Cli.CommandOption("--connection-string <STRING>")]
+    [System.ComponentModel.Description("Database connection string")]
+    public string ConnectionString { get; set; }
+
+    [Spectre.Console.Cli.CommandOption("--table-query <SQL>")]
+    [System.ComponentModel.Description("SQL query used to list tables")]
+    public string TableQuery { get; set; }
+
+    [Spectre.Console.Cli.CommandOption("--allow-custom-query")]
+    [System.ComponentModel.Description("Allow an explicitly provided custom --table-query")]
+    public bool AllowCustomQuery { get; set; }
+
+    [Spectre.Console.Cli.CommandOption("--dbtype <TYPE>")]
+    [System.ComponentModel.Description("Database type: SqlServer, Oracle, PostgreSql, MySql")]
+    public string DatabaseType { get; set; }
+
+    [Spectre.Console.Cli.CommandOption("--include-tables <CSV>")]
+    [System.ComponentModel.Description("Comma-separated fully qualified tables to include (schema.table)")]
+    public string IncludeTables { get; set; }
+
+    [Spectre.Console.Cli.CommandOption("--exclude-tables <CSV>")]
+    [System.ComponentModel.Description("Comma-separated fully qualified tables to exclude (schema.table)")]
+    public string ExcludeTables { get; set; }
+
+    [Spectre.Console.Cli.CommandOption("--max-tables <COUNT>")]
+    [System.ComponentModel.Description("Maximum number of tables returned in JSON payload")]
+    public int MaxTables { get; set; } = 200;
+
+    [Spectre.Console.Cli.CommandOption("--pretty-json")]
+    [System.ComponentModel.Description("Render JSON output with indentation")]
+    public bool PrettyJson { get; set; }
+
+    [Spectre.Console.Cli.CommandOption("--verbose")]
+    [System.ComponentModel.Description("Enable verbose database table logging")]
+    public bool Verbose { get; set; }
+}
+
+internal sealed class ResolvedDatabaseRequest
+{
+    public string ConnectionString { get; set; }
+    public DatabaseType DatabaseType { get; set; }
+    public string Query { get; set; }
+}

--- a/DB2ERD/Commands/McpCommands.cs
+++ b/DB2ERD/Commands/McpCommands.cs
@@ -1,0 +1,279 @@
+using DB2ERD.Controller;
+using DB2ERD.Model;
+using Spectre.Console.Cli;
+
+namespace DB2ERD.Commands;
+
+public sealed class ListSupportedDatabasesCommand : Command<ListSupportedDatabasesCommand.Settings>
+{
+    public sealed class Settings : CommandSettings
+    {
+        [CommandOption("--pretty-json")]
+        [System.ComponentModel.Description("Render JSON output with indentation")]
+        public bool PrettyJson { get; set; }
+    }
+
+    public override int Execute(CommandContext context, Settings settings)
+    {
+        var databases = Enum.GetValues<DatabaseType>()
+            .Select(dbType => new SupportedDatabaseItem
+            {
+                Name = dbType.ToString(),
+                DefaultIntrospectionQuery = DatabaseCommandSupport.GetDefaultTableQuery(dbType)
+            })
+            .ToList();
+
+        var payload = new SupportedDatabasesPayload
+        {
+            Databases = databases
+        };
+
+        DatabaseCommandSupport.WriteSuccess(payload, settings.PrettyJson);
+        return 0;
+    }
+}
+
+public sealed class GetSchemaMetadataCommand : Command<GetSchemaMetadataCommand.Settings>
+{
+    /// <summary>
+    /// Optional table generator used for testing. When not set, a generator is created
+    /// based on the selected database type.
+    /// </summary>
+    public ITableGenerator TableGenerator { get; set; }
+
+    public sealed class Settings : DatabaseAccessSettings
+    {
+    }
+
+    public override int Execute(CommandContext context, Settings settings)
+    {
+        if (settings.MaxTables < 1)
+        {
+            DatabaseCommandSupport.WriteError(
+                "INVALID_MAX_TABLES",
+                "--max-tables must be greater than zero.",
+                settings.PrettyJson);
+            return -1;
+        }
+
+        if (!DatabaseCommandSupport.TryResolveRequest(
+            settings,
+            safeQueryMode: true,
+            out var request,
+            out var errorCode,
+            out var errorMessage))
+        {
+            DatabaseCommandSupport.WriteError(errorCode, errorMessage, settings.PrettyJson);
+            return -1;
+        }
+
+        try
+        {
+            var generator = TableGenerator ?? DatabaseCommandSupport.CreateTableGenerator(
+                request.DatabaseType,
+                request.ConnectionString,
+                settings.Verbose,
+                throwOnError: true);
+
+            var includeTables = DatabaseCommandSupport.ParseTableList(settings.IncludeTables);
+            var excludeTables = DatabaseCommandSupport.ParseTableList(settings.ExcludeTables);
+
+            var allTables = generator.Execute(request.Query, includeTables, excludeTables) ?? new List<SqlTable>();
+            var limitedTables = DatabaseCommandSupport.ApplyTableLimit(allTables, settings.MaxTables, out var truncated, out var totalTableCount);
+
+            var payload = new SchemaMetadataPayload
+            {
+                DatabaseType = request.DatabaseType.ToString(),
+                SafeQueryMode = !settings.AllowCustomQuery,
+                Truncated = truncated,
+                TotalTableCount = totalTableCount,
+                ReturnedTableCount = limitedTables.Count,
+                RelationshipCount = DatabaseCommandSupport.CountRelationships(limitedTables),
+                Tables = limitedTables
+            };
+
+            DatabaseCommandSupport.WriteSuccess(payload, settings.PrettyJson);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            DatabaseCommandSupport.WriteError("SCHEMA_READ_FAILED", ex.Message, settings.PrettyJson);
+            return -1;
+        }
+    }
+}
+
+public sealed class GenerateErdPumlCommand : Command<GenerateErdPumlCommand.Settings>
+{
+    /// <summary>
+    /// Optional table generator used for testing. When not set, a generator is created
+    /// based on the selected database type.
+    /// </summary>
+    public ITableGenerator TableGenerator { get; set; }
+
+    public sealed class Settings : DatabaseAccessSettings
+    {
+        [CommandOption("--mode <MODE>")]
+        [System.ComponentModel.Description("Diagram mode: all-relationships, all-tables, isolated-tables")]
+        public string Mode { get; set; } = "all-relationships";
+
+        [CommandOption("--output-file <FILE>")]
+        [System.ComponentModel.Description("Optional path to write the generated PlantUML diagram")]
+        public string OutputFile { get; set; }
+
+        [CommandOption("--max-output-chars <COUNT>")]
+        [System.ComponentModel.Description("Maximum number of PlantUML characters included in JSON response")]
+        public int MaxOutputChars { get; set; } = 200000;
+
+        [CommandOption("--exclude-missing-relationships")]
+        [System.ComponentModel.Description("Exclude relationships that point to missing tables (all-tables mode only)")]
+        public bool ExcludeMissingRelationships { get; set; }
+    }
+
+    public override int Execute(CommandContext context, Settings settings)
+    {
+        if (settings.MaxTables < 1)
+        {
+            DatabaseCommandSupport.WriteError(
+                "INVALID_MAX_TABLES",
+                "--max-tables must be greater than zero.",
+                settings.PrettyJson);
+            return -1;
+        }
+
+        if (settings.MaxOutputChars < 1)
+        {
+            DatabaseCommandSupport.WriteError(
+                "INVALID_MAX_OUTPUT_CHARS",
+                "--max-output-chars must be greater than zero.",
+                settings.PrettyJson);
+            return -1;
+        }
+
+        if (!DatabaseCommandSupport.TryResolveRequest(
+            settings,
+            safeQueryMode: true,
+            out var request,
+            out var errorCode,
+            out var errorMessage))
+        {
+            DatabaseCommandSupport.WriteError(errorCode, errorMessage, settings.PrettyJson);
+            return -1;
+        }
+
+        try
+        {
+            var generator = TableGenerator ?? DatabaseCommandSupport.CreateTableGenerator(
+                request.DatabaseType,
+                request.ConnectionString,
+                settings.Verbose,
+                throwOnError: true);
+
+            var includeTables = DatabaseCommandSupport.ParseTableList(settings.IncludeTables);
+            var excludeTables = DatabaseCommandSupport.ParseTableList(settings.ExcludeTables);
+
+            var allTables = generator.Execute(request.Query, includeTables, excludeTables) ?? new List<SqlTable>();
+            var limitedTables = DatabaseCommandSupport.ApplyTableLimit(allTables, settings.MaxTables, out var tablesTruncated, out var totalTableCount);
+
+            if (limitedTables.Count == 0)
+            {
+                DatabaseCommandSupport.WriteError("NO_TABLES_FOUND", "No tables found.", settings.PrettyJson);
+                return -1;
+            }
+
+            var mode = settings.Mode?.Trim().ToLowerInvariant() ?? string.Empty;
+            string puml;
+
+            switch (mode)
+            {
+                case "all-relationships":
+                    puml = GeneratePlantUMLDiagram.GenerateAllRelationships(limitedTables, "ERD", settings.OutputFile);
+                    break;
+                case "all-tables":
+                    puml = GeneratePlantUMLDiagram.GenerateAllTables(
+                        limitedTables,
+                        "ERD",
+                        settings.OutputFile,
+                        settings.ExcludeMissingRelationships);
+                    break;
+                case "isolated-tables":
+                    puml = GeneratePlantUMLDiagram.GenerateTablesWithNoRelationships(limitedTables, "ERD", settings.OutputFile);
+                    break;
+                default:
+                    DatabaseCommandSupport.WriteError(
+                        "INVALID_MODE",
+                        "Unknown mode. Supported values: all-relationships, all-tables, isolated-tables.",
+                        settings.PrettyJson);
+                    return -1;
+            }
+
+            var outputPuml = puml;
+            var pumlTruncated = false;
+            if (outputPuml.Length > settings.MaxOutputChars)
+            {
+                outputPuml = outputPuml[..settings.MaxOutputChars];
+                pumlTruncated = true;
+            }
+
+            var payload = new ErdPumlPayload
+            {
+                DatabaseType = request.DatabaseType.ToString(),
+                Mode = mode,
+                SafeQueryMode = !settings.AllowCustomQuery,
+                TablesTruncated = tablesTruncated,
+                TotalTableCount = totalTableCount,
+                ReturnedTableCount = limitedTables.Count,
+                RelationshipCount = DatabaseCommandSupport.CountRelationships(limitedTables),
+                PumlTruncated = pumlTruncated,
+                PumlLength = puml.Length,
+                Puml = outputPuml,
+                OutputFile = settings.OutputFile
+            };
+
+            DatabaseCommandSupport.WriteSuccess(payload, settings.PrettyJson);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            DatabaseCommandSupport.WriteError("ERD_GENERATION_FAILED", ex.Message, settings.PrettyJson);
+            return -1;
+        }
+    }
+}
+
+public sealed class SupportedDatabasesPayload
+{
+    public List<SupportedDatabaseItem> Databases { get; set; } = new();
+}
+
+public sealed class SupportedDatabaseItem
+{
+    public string Name { get; set; }
+    public string DefaultIntrospectionQuery { get; set; }
+}
+
+public sealed class SchemaMetadataPayload
+{
+    public string DatabaseType { get; set; }
+    public bool SafeQueryMode { get; set; }
+    public bool Truncated { get; set; }
+    public int TotalTableCount { get; set; }
+    public int ReturnedTableCount { get; set; }
+    public int RelationshipCount { get; set; }
+    public List<SqlTable> Tables { get; set; }
+}
+
+public sealed class ErdPumlPayload
+{
+    public string DatabaseType { get; set; }
+    public string Mode { get; set; }
+    public bool SafeQueryMode { get; set; }
+    public bool TablesTruncated { get; set; }
+    public int TotalTableCount { get; set; }
+    public int ReturnedTableCount { get; set; }
+    public int RelationshipCount { get; set; }
+    public bool PumlTruncated { get; set; }
+    public int PumlLength { get; set; }
+    public string Puml { get; set; }
+    public string OutputFile { get; set; }
+}

--- a/DB2ERD/Controller/GenerateMySqlTables.cs
+++ b/DB2ERD/Controller/GenerateMySqlTables.cs
@@ -9,11 +9,15 @@ namespace DB2ERD.Controller
     public class GenerateMySqlTables : ITableGenerator
     {
         private readonly string _connStr;
+        private readonly bool _verbose;
+        private readonly bool _throwOnError;
         private List<SqlTable> _tableList = new();
 
-        public GenerateMySqlTables(string connStr)
+        public GenerateMySqlTables(string connStr, bool verbose = true, bool throwOnError = false)
         {
             _connStr = connStr;
+            _verbose = verbose;
+            _throwOnError = throwOnError;
         }
 
         /// <inheritdoc />
@@ -32,7 +36,10 @@ namespace DB2ERD.Controller
                     if (tablesToInclude != null && !tablesToInclude.Contains(fullName))
                         continue;
 
-                    AnsiConsole.MarkupLine($"[{row.schema_name}].[{row.table_name}]");
+                    if (_verbose)
+                    {
+                        AnsiConsole.MarkupLine($"[{row.schema_name}].[{row.table_name}]");
+                    }
                     var table = new SqlTable
                     {
                         schema_name = row.schema_name,
@@ -48,7 +55,15 @@ namespace DB2ERD.Controller
             }
             catch (Exception ex)
             {
-                AnsiConsole.MarkupLine($"[red]Failed to execute table query: {ex.Message}[/]");
+                if (_verbose)
+                {
+                    AnsiConsole.MarkupLine($"[red]Failed to execute table query: {ex.Message}[/]");
+                }
+
+                if (_throwOnError)
+                {
+                    throw new InvalidOperationException("Failed to execute table query.", ex);
+                }
             }
             return _tableList;
         }

--- a/DB2ERD/Controller/GenerateOracleTables.cs
+++ b/DB2ERD/Controller/GenerateOracleTables.cs
@@ -9,11 +9,15 @@ namespace DB2ERD.Controller
     public class GenerateOracleTables : ITableGenerator
     {
         private readonly string _connStr;
+        private readonly bool _verbose;
+        private readonly bool _throwOnError;
         private List<SqlTable> _tableList = new();
 
-        public GenerateOracleTables(string dbConnString)
+        public GenerateOracleTables(string dbConnString, bool verbose = true, bool throwOnError = false)
         {
             _connStr = dbConnString;
+            _verbose = verbose;
+            _throwOnError = throwOnError;
         }
 
         /// <inheritdoc />
@@ -32,7 +36,10 @@ namespace DB2ERD.Controller
                     if (tablesToInclude != null && !tablesToInclude.Contains(fullName))
                         continue;
 
-                    AnsiConsole.MarkupLine($"[{row.schema_name}].[{row.table_name}]");
+                    if (_verbose)
+                    {
+                        AnsiConsole.MarkupLine($"[{row.schema_name}].[{row.table_name}]");
+                    }
                     var table = new SqlTable
                     {
                         schema_name = row.schema_name,
@@ -48,7 +55,15 @@ namespace DB2ERD.Controller
             }
             catch (Exception ex)
             {
-                AnsiConsole.MarkupLine($"[red]Failed to execute table query: {ex.Message}[/]");
+                if (_verbose)
+                {
+                    AnsiConsole.MarkupLine($"[red]Failed to execute table query: {ex.Message}[/]");
+                }
+
+                if (_throwOnError)
+                {
+                    throw new InvalidOperationException("Failed to execute table query.", ex);
+                }
             }
             return _tableList;
         }

--- a/DB2ERD/Controller/GeneratePlantUMLDiagram.cs
+++ b/DB2ERD/Controller/GeneratePlantUMLDiagram.cs
@@ -28,7 +28,7 @@ namespace DB2ERD.Controller
         /// When true, excludes relationships to tables not in the tableList.
         /// </param>
         /// <returns>The generated PlantUML text.</returns>
-        public static string GenerateAllTables(List<SqlTable> tableList, string title, string fileName, bool excludeRelationshipsToTablesThatDontExist = false)
+        public static string GenerateAllTables(List<SqlTable> tableList, string title, string fileName = "", bool excludeRelationshipsToTablesThatDontExist = false)
         {
             return GenerateDiagram(tableList, fileName, excludeRelationshipsToTablesThatDontExist);
         }
@@ -41,7 +41,7 @@ namespace DB2ERD.Controller
         /// <param name="title">Title for the diagram (not currently used in output).</param>
         /// <param name="fileName">Path to the output PlantUML file.</param>
         /// <returns>The generated PlantUML text.</returns>
-        public static string GenerateTablesWithNoRelationships(List<SqlTable> tableList, string title, string fileName)
+        public static string GenerateTablesWithNoRelationships(List<SqlTable> tableList, string title, string fileName = "")
         {
             var isolatedTables = FilterIsolatedTables(tableList);
             return GenerateDiagram(isolatedTables, fileName, false);
@@ -55,7 +55,7 @@ namespace DB2ERD.Controller
         /// <param name="title">Title for the diagram (not currently used in output).</param>
         /// <param name="fileName">Path to the output PlantUML file.</param>
         /// <returns>The generated PlantUML text.</returns>
-        public static string GenerateAllRelationships(List<SqlTable> tableList, string title, string fileName)
+        public static string GenerateAllRelationships(List<SqlTable> tableList, string title, string fileName = "")
         {
             var relatedTables = FilterRelatedTables(tableList);
             return GenerateDiagram(relatedTables, fileName, false);
@@ -120,7 +120,10 @@ namespace DB2ERD.Controller
             sb.AppendLine("@enduml");
 
             var text = sb.ToString();
-            File.WriteAllText(fileName, text);
+            if (!string.IsNullOrWhiteSpace(fileName))
+            {
+                File.WriteAllText(fileName, text);
+            }
 
             return text;
         }

--- a/DB2ERD/Controller/GeneratePostgreSqlTables.cs
+++ b/DB2ERD/Controller/GeneratePostgreSqlTables.cs
@@ -9,11 +9,15 @@ namespace DB2ERD.Controller
     public class GeneratePostgreSqlTables : ITableGenerator
     {
         private readonly string _connStr;
+        private readonly bool _verbose;
+        private readonly bool _throwOnError;
         private List<SqlTable> _tableList = new();
 
-        public GeneratePostgreSqlTables(string connStr)
+        public GeneratePostgreSqlTables(string connStr, bool verbose = true, bool throwOnError = false)
         {
             _connStr = connStr;
+            _verbose = verbose;
+            _throwOnError = throwOnError;
         }
 
         /// <inheritdoc />
@@ -32,7 +36,10 @@ namespace DB2ERD.Controller
                     if (tablesToInclude != null && !tablesToInclude.Contains(fullName))
                         continue;
 
-                    AnsiConsole.MarkupLine($"[{row.schema_name}].[{row.table_name}]");
+                    if (_verbose)
+                    {
+                        AnsiConsole.MarkupLine($"[{row.schema_name}].[{row.table_name}]");
+                    }
                     var table = new SqlTable
                     {
                         schema_name = row.schema_name,
@@ -48,7 +55,15 @@ namespace DB2ERD.Controller
             }
             catch (Exception ex)
             {
-                AnsiConsole.MarkupLine($"[red]Failed to execute table query: {ex.Message}[/]");
+                if (_verbose)
+                {
+                    AnsiConsole.MarkupLine($"[red]Failed to execute table query: {ex.Message}[/]");
+                }
+
+                if (_throwOnError)
+                {
+                    throw new InvalidOperationException("Failed to execute table query.", ex);
+                }
             }
             return _tableList;
         }

--- a/DB2ERD/Controller/GenerateSqlServerTables.cs
+++ b/DB2ERD/Controller/GenerateSqlServerTables.cs
@@ -9,11 +9,15 @@ namespace DB2ERD.Controller
     public class GenerateSqlServerTables : ITableGenerator
     {
         private readonly string _connectionString;
+        private readonly bool _verbose;
+        private readonly bool _throwOnError;
         private List<SqlTable> _tableList = new List<SqlTable>();
 
-        public GenerateSqlServerTables(string dbConnString)
+        public GenerateSqlServerTables(string dbConnString, bool verbose = true, bool throwOnError = false)
         {
             _connectionString = dbConnString;
+            _verbose = verbose;
+            _throwOnError = throwOnError;
         }
 
         /// <inheritdoc />
@@ -40,7 +44,10 @@ namespace DB2ERD.Controller
                             if (tablesToInclude != null && !tablesToInclude.Contains(fullName))
                                 continue;
 
-                            AnsiConsole.MarkupLine($"[{row.schema_name}].[{row.table_name}]");
+                            if (_verbose)
+                            {
+                                AnsiConsole.MarkupLine($"[{row.schema_name}].[{row.table_name}]");
+                            }
 
                             var table = new SqlTable
                             {
@@ -60,14 +67,32 @@ namespace DB2ERD.Controller
                         }
                         catch (Exception ex)
                         {
-                            AnsiConsole.MarkupLine($"[red]Failed to process table {row.schema_name}.{row.table_name}: {ex.Message}[/]");
+                            if (_verbose)
+                            {
+                                AnsiConsole.MarkupLine($"[red]Failed to process table {row.schema_name}.{row.table_name}: {ex.Message}[/]");
+                            }
+
+                            if (_throwOnError)
+                            {
+                                throw new InvalidOperationException(
+                                    $"Failed to process table {row.schema_name}.{row.table_name}.",
+                                    ex);
+                            }
                         }
                     }
                 }
             }
             catch (Exception ex)
             {
-                AnsiConsole.MarkupLine($"[red]Failed to execute table query: {ex.Message}[/]");
+                if (_verbose)
+                {
+                    AnsiConsole.MarkupLine($"[red]Failed to execute table query: {ex.Message}[/]");
+                }
+
+                if (_throwOnError)
+                {
+                    throw new InvalidOperationException("Failed to execute table query.", ex);
+                }
             }
 
             return _tableList;

--- a/DB2ERD/Program.cs
+++ b/DB2ERD/Program.cs
@@ -1,8 +1,8 @@
 using Spectre.Console;
 using Spectre.Console.Cli;
+using DB2ERD.Commands;
 using DB2ERD.Controller;
 using System.ComponentModel;
-
 using System.Text.Json;
 
 namespace DB2ERD;
@@ -11,7 +11,22 @@ internal class Program
 {
     public static int Main(string[] args)
     {
-        var app = new CommandApp<ErdGeneration>();
+        var app = new CommandApp();
+        app.Configure(config =>
+        {
+            config.SetApplicationName("db2erd");
+            config.SetDefaultCommand<ErdGeneration>();
+
+            config.AddCommand<ErdGeneration>("generate-file")
+                .WithDescription("Legacy file-oriented ERD generation command.");
+            config.AddCommand<ListSupportedDatabasesCommand>("list-supported-databases")
+                .WithDescription("List supported databases and default introspection queries.");
+            config.AddCommand<GetSchemaMetadataCommand>("get-schema-metadata")
+                .WithDescription("Return schema metadata as structured JSON.");
+            config.AddCommand<GenerateErdPumlCommand>("generate-erd-puml")
+                .WithDescription("Generate PlantUML text and return it as structured JSON.");
+        });
+
         return app.Run(args);
     }
 }
@@ -78,14 +93,7 @@ public class ErdGeneration : Command<ErdGeneration.Settings>
             return -1;
         }
 
-        var defaultQuery = dbType switch
-        {
-            DatabaseType.SqlServer => "SELECT schema_id, SCHEMA_NAME(schema_id) as [schema_name], name as table_name, object_id, '['+SCHEMA_NAME(schema_id)+'].['+name+']' AS full_name FROM sys.tables where is_ms_shipped = 0",
-            DatabaseType.Oracle => "SELECT owner AS schema_name, table_name, owner||'.'||table_name AS full_name FROM all_tables WHERE owner NOT IN ('SYS','SYSTEM')",
-            DatabaseType.PostgreSql => "SELECT table_schema AS schema_name, table_name, table_schema||'.'||table_name AS full_name FROM information_schema.tables WHERE table_type='BASE TABLE' AND table_schema NOT IN ('pg_catalog','information_schema')",
-            DatabaseType.MySql => "SELECT table_schema AS schema_name, table_name, CONCAT(table_schema,'.',table_name) AS full_name FROM information_schema.tables WHERE table_type='BASE TABLE' AND table_schema = DATABASE()",
-            _ => string.Empty
-        };
+        var defaultQuery = DatabaseCommandSupport.GetDefaultTableQuery(dbType);
 
         // Prefer a query passed on the command line. If none is specified,
         // look for one in the configuration file. When both are missing or

--- a/README.md
+++ b/README.md
@@ -80,10 +80,67 @@ Update these values to match your environment before running the program.
 
 ## Usage
 
-Run the executable with options to override values from the configuration file:
+DB2ERD now supports both:
+
+- a legacy file-oriented command (`generate-file`, also the default command)
+- machine-friendly JSON commands that are suitable for MCP wrappers
+
+### MCP-friendly commands
+
+List supported databases and built-in introspection queries:
 
 ```bash
-dotnet DB2ERD.dll \
+dotnet DB2ERD.dll list-supported-databases --pretty-json
+```
+
+Read schema metadata as structured JSON:
+
+```bash
+dotnet DB2ERD.dll get-schema-metadata \
+    --config appsettings.json \
+    --connection-string "Server=.;Database=MyDb;Trusted_Connection=True;" \
+    --dbtype SqlServer \
+    --max-tables 200 \
+    --pretty-json
+```
+
+Generate PlantUML and return it in JSON (no file write unless requested):
+
+```bash
+dotnet DB2ERD.dll generate-erd-puml \
+    --config appsettings.json \
+    --connection-string "Server=.;Database=MyDb;Trusted_Connection=True;" \
+    --dbtype SqlServer \
+    --mode all-relationships \
+    --max-output-chars 200000 \
+    --pretty-json
+```
+
+Optional file output is explicit:
+
+```bash
+dotnet DB2ERD.dll generate-erd-puml \
+    --connection-string "Server=.;Database=MyDb;Trusted_Connection=True;" \
+    --dbtype SqlServer \
+    --output-file diagram.puml
+```
+
+By default, MCP-friendly commands use built-in read-only metadata queries. To run a custom table query, you must opt in explicitly:
+
+```bash
+dotnet DB2ERD.dll get-schema-metadata \
+    --connection-string "..." \
+    --dbtype SqlServer \
+    --allow-custom-query \
+    --table-query "SELECT ..."
+```
+
+### Legacy file-oriented command
+
+Run the legacy command explicitly:
+
+```bash
+dotnet DB2ERD.dll generate-file \
     --config appsettings.json \
     --connection-string "Server=.;Database=MyDb;Trusted_Connection=True;" \
     --table-query "SELECT ..." \
@@ -94,7 +151,7 @@ dotnet DB2ERD.dll \
 Or in PowerShell:
 
 ```powershell
-PS> .\DB2ERD.exe `
+PS> .\DB2ERD.exe generate-file `
     --config appsettings.json `
     --connection-string "Server=.;Database=MyDb;Trusted_Connection=True;" `
     --table-query "SELECT ..." `
@@ -106,9 +163,11 @@ If an option is omitted, the value from the specified configuration file is used
 
 ## Output
 
-The tool writes the PlantUML description to a file (for example `diagram.puml`).  This text file contains the tables and their relationships in PlantUML syntax.  You can feed the file to the [PlantUML](https://plantuml.com/) command line utility or any compatible viewer to generate visual diagrams in formats such as PNG or SVG.
+`generate-erd-puml` returns PlantUML as text in JSON by default and can optionally write a `.puml` file when `--output-file` is set.
 
-To render the diagram with the command line tool:
+`generate-file` writes the PlantUML description directly to a file (for example `diagram.puml`). This text file contains the tables and relationships in PlantUML syntax.
+
+To render a `.puml` file with the command line tool:
 
 ```bash
 plantuml diagram.puml
@@ -133,7 +192,9 @@ Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for gui
 
 ## Security
 
-This tool uses parameterized queries to prevent SQL injection attacks. All user inputs are properly sanitized before being used in database queries. If you discover a security vulnerability, please report it privately to the maintainers.
+DB2ERD uses parameterized queries for metadata lookups. MCP-friendly commands default to built-in introspection queries and require explicit opt-in (`--allow-custom-query`) before executing a custom `--table-query`.
+
+If you discover a security vulnerability, please report it privately to the maintainers.
 
 ## Changelog
 


### PR DESCRIPTION
Refactor CLI to introduce MCP-friendly commands with structured JSON output, safer query handling, and bounded results.

The original CLI was file-oriented and allowed direct execution of custom SQL queries, posing safety and integration challenges for machine-driven workflows. This PR introduces new commands that return structured JSON, enforce read-only introspection by default, provide output bounding, and make file writing an explicit option, aligning the tool with MCP best practices for safety and composability.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-22117a29-d108-4422-b394-9ee8129375ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-22117a29-d108-4422-b394-9ee8129375ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

